### PR TITLE
New configuration entry and related UI change

### DIFF
--- a/gopolloplus.go
+++ b/gopolloplus.go
@@ -165,6 +165,9 @@ func main() {
   button_c2 := widget.NewButtonWithIcon("Send to log.C2", theme.MailForwardIcon(), func() {
     log.Print("Sending data to log.C2")
   })
+  if !cfg.Concept2 {
+    button_c2.Disable()
+  }
 
   button_theme := widget.NewCheck("Dark Theme", func(checked bool) {
     if checked {

--- a/pkg/apolloUtils/types.go
+++ b/pkg/apolloUtils/types.go
@@ -11,13 +11,12 @@ import (
 )
 
 type ApolloConfig struct {
-  FullScreen bool
+  Concept2, FullScreen bool
   ConfigFile, ThemeVariant, Socket, LogFile, HistoryDir string
   Theme fyne.Theme
 }
 
 func (a *ApolloConfig) Write() {
-  // TODO: dump config to file (override)
   // Note: Write must override the existing config file
   cfg_file, err := os.OpenFile(a.ConfigFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
   if err != nil {
@@ -45,6 +44,7 @@ func DefaultConfig() *ApolloConfig {
     ConfigFile: standard_cfg,
     ThemeVariant: "dark",
     Theme: theme.DarkTheme(),
+    Concept2: false,
   }
 
   return config
@@ -92,6 +92,7 @@ func LoadConfig(config_file string) *ApolloConfig {
     Theme: th,
     ThemeVariant: variant,
     ConfigFile: config_file,
+    Concept2: false,
   }
 
   return config


### PR DESCRIPTION
This allows to toggle button state for "Send to log.C2". For now,
defaults to "false" without any other option, since the feature isn't
implemented yet.